### PR TITLE
Dev

### DIFF
--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -744,7 +744,8 @@ namespace YARG.Gameplay
             if (!PlayerHasFailed)
             {
                 if (APEvents._isConnected && APEvents.deathLinkService != null && APEvents.deathLinkOverride != 1)
-                    APEvents.deathLinkService.SendDeathLink(new Archipelago.MultiClient.Net.BounceFeatures.DeathLink.DeathLink(APEvents.session.Players.ActivePlayer.Name, $"Failed song {Song.Name}"));
+                    APEvents.deathLinkService.SendDeathLink(new Archipelago.MultiClient.Net.BounceFeatures.DeathLink.DeathLink(
+                        APEvents.session.Players.ActivePlayer.Name, APEvents.GetRandomDeatLinkMessage(this, _players)));
                 await ForceSongFail();
             }
         }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -232,8 +233,24 @@ namespace YARG.Gameplay
             Screen.sleepTimeout = _originalSleepTimeout;
         }
 
+        private bool HasShownGoalWarning = false;
         private void Update()
         {
+            if (!HasShownGoalWarning && APEvents.GoalSong == Song.Name && !APEvents.CanCompleteGoalSong() && !IsPractice)
+            {
+                StringBuilder Error = new StringBuilder();
+
+                Error.AppendLine("You have selected your goal song but you do not have the items needed to complete it!");
+                if (APEvents.GoalItemNeeded > APEvents.GoalItemCount)
+                    Error.AppendLine($"\nYou have {APEvents.GoalItemCount} Gems, but you need {APEvents.GoalItemNeeded}!");
+                if (!APEvents.RecievedSongs.Contains(APEvents.GoalSong))
+                    Error.AppendLine($"\nYou have not found your goal song item!");
+
+                SetPaused(!_pauseMenu.IsOpen);
+                DialogManager.Instance.ShowMessage("Goal Song Not Unlocked", Error.ToString());
+            }
+            HasShownGoalWarning = true;
+
             // Pause/unpause
             if (Keyboard.current.escapeKey.wasPressedThisFrame)
             {

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -726,7 +726,7 @@ namespace YARG.Gameplay
 
             if (!PlayerHasFailed)
             {
-                if (APEvents._isConnected && APEvents.deathLinkService != null)
+                if (APEvents._isConnected && APEvents.deathLinkService != null && APEvents.deathLinkOverride != 1)
                     APEvents.deathLinkService.SendDeathLink(new Archipelago.MultiClient.Net.BounceFeatures.DeathLink.DeathLink(APEvents.session.Players.ActivePlayer.Name, $"Failed song {Song.Name}"));
                 await ForceSongFail();
             }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using TMPro;
 using UnityEngine;
@@ -464,24 +465,36 @@ namespace YARG.Menu.MusicLibrary
                     list.Add(new CategoryViewType(
                         Localize.Key("Menu.MusicLibrary.AllSongs"), songCount, SongContainer.Songs));
 
-
                     var AvailableSongs = APEvents.GetUnplayedAvailableLocations();
                     var HasGoalSong = AvailableSongs.Remove(APEvents.GoalSong);
                     var HasGoalItems = APEvents.GoalItemCount >= APEvents.GoalItemNeeded;
-                    var ShouldDisplayGoal =
+                    var ShouldDisplayGoalSong =
                         APEvents.goalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
                         (HasGoalSong && APEvents.goalDisplaySetting == APData.GoalDisplaySetting.song) ||
                         (HasGoalItems && APEvents.goalDisplaySetting == APData.GoalDisplaySetting.gems) ||
-                        (HasGoalItems && HasGoalSong && APEvents.goalDisplaySetting == APData.GoalDisplaySetting.both);
+                        (HasGoalSong && HasGoalItems && APEvents.goalDisplaySetting == APData.GoalDisplaySetting.both);
 
-                    if (ShouldDisplayGoal)
+                    if (ShouldDisplayGoalSong)
                     {
-                        var GoalSong = SongContainer.Songs.FirstOrDefault(x => x.Name == APEvents.GoalSong);
-                        if (GoalSong != null)
-                        {
-                            list.Add(new CategoryViewType("Archipelago GOAL Song", 1, new SongEntry[] { GoalSong }, RefreshAndReselect));
-                            list.Add(new SongViewType(this, GoalSong));
-                        }
+                        if (APEvents.goalDisplaySetting == APData.GoalDisplaySetting.song ||
+                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
+                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.both)
+                            list.Add(new CategoryViewType($"Gems {APEvents.GoalItemCount}\\{APEvents.GoalItemNeeded}", 0, new SongEntry[0], RefreshAndReselect));
+
+                        if (APEvents.goalDisplaySetting == APData.GoalDisplaySetting.gems ||
+                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
+                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.both)
+                            list.Add(new CategoryViewType($"Goal Song Item: {(HasGoalSong ? "Found" : "Missing")}", 0, new SongEntry[0], RefreshAndReselect));
+                    }
+
+                    var GoalSong = SongContainer.Songs.FirstOrDefault(x => x.Name == APEvents.GoalSong);
+                    if (GoalSong == null)
+                        ShouldDisplayGoalSong = false;
+
+                    if (ShouldDisplayGoalSong)
+                    {
+                        list.Add(new CategoryViewType("AP Goal Song", 1, new SongEntry[] { GoalSong }, RefreshAndReselect));
+                        list.Add(new SongViewType(this, GoalSong));
                     }
 
                     if (AvailableSongs.Count > 0)
@@ -498,7 +511,7 @@ namespace YARG.Menu.MusicLibrary
                         }
                         if (AvailableAPSongs.Count > 0)
                         {
-                            list.Add(new CategoryViewType("Archipelago Songs", AvailableAPSongs.Count, AvailableAPSongs.ToArray(), RefreshAndReselect));
+                            list.Add(new CategoryViewType("AP Songs", AvailableAPSongs.Count, AvailableAPSongs.ToArray(), RefreshAndReselect));
                             foreach (var song in AvailableAPSongs)
                                 list.Add(new SongViewType(this, song));
                         }

--- a/Assets/Script/YargAP/APData.cs
+++ b/Assets/Script/YargAP/APData.cs
@@ -3,11 +3,35 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using YARG.Core;
 
 namespace YARG.Assets.Script.YargAP
 {
     internal class APData
     {
+        public static List<DeathLinkMessage> DeathLinkMessages = new()
+        {
+            new("got boo'd offstage."),
+            new("tripped over a cable."),
+            new("failed a stage dive."),
+            new("dropped their pick.", new(){Instrument.FiveFretGuitar, Instrument.FiveFretBass, Instrument.FiveFretRhythm, Instrument.FiveFretCoopGuitar}),
+            new("dropped their last drum sticks.", new(){Instrument.EliteDrums, Instrument.FourLaneDrums, Instrument.ProDrums, Instrument.FiveLaneDrums}),
+            new("dropped the mic.", new(){Instrument.Vocals, Instrument.Harmony}),
+            new("knocked over the keyboard.", new(){Instrument.Keys, Instrument.ProKeys}),
+        };
+        public class DeathLinkMessage
+        {
+            public DeathLinkMessage(string message, HashSet<Instrument> instruments = null)
+            {
+                Message = message;
+                InstrumentTags = instruments ?? new HashSet<Instrument>();
+            }
+            public string Message;
+            public HashSet<Instrument> InstrumentTags = new();
+            public override string ToString() => Message;
+            public bool Valid(Instrument instrument) => InstrumentTags.Count == 0 || InstrumentTags.Contains(instrument);
+        }
+
         public static bool NeedsRegen = true;
         public enum APFiller
         {

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -124,10 +124,12 @@ namespace YARG.Assets.Script.YargAP
             if (APData.SongHashToAPLocations().TryGetValue(gameManager.Song.Name, out var Locations))
                 session.Locations.CompleteLocationChecksAsync(Locations);
 
-            if (GoalSong != null && GoalSong == gameManager.Song.Name && GoalItemCount >= GoalItemNeeded)
+            if (GoalSong != null && GoalSong == gameManager.Song.Name && CanCompleteGoalSong())
                 session.SetGoalAchieved();
 
         }
+
+        public static bool CanCompleteGoalSong() => _isConnected && RecievedSongs.Contains(GoalSong) && GoalItemCount >= GoalItemNeeded;
 
         public static void ProcessDeathLink(DeathLink deathLink)
         {

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -27,9 +27,19 @@ namespace YARG.Assets.Script.YargAP
         public static ArchipelagoSession session;
         public static DeathLinkService deathLinkService;
         public static APData.DeathLinkType deathLinkType = APData.DeathLinkType.RockMeter;
+        public static int deathLinkOverride = 0;
         public static bool _isConnected => APEvents.session?.Socket != null && APEvents.session.Socket.Connected;
 
         public static HashSet<string> RecievedSongs = new HashSet<string>();
+
+        public static APData.DeathLinkType GetDeathLinkSetting()
+        {
+            if (deathLinkOverride == 2)
+                return APData.DeathLinkType.Fail;
+            if (deathLinkOverride == 3)
+                return APData.DeathLinkType.RockMeter;
+            return deathLinkType;
+        }
 
         public static void UpdateRecievedSongs()
         {
@@ -121,15 +131,16 @@ namespace YARG.Assets.Script.YargAP
 
         public static void ProcessDeathLink(DeathLink deathLink)
         {
-            if (CurrentSong == null)
+            if (CurrentSong == null || deathLinkOverride == 1)
                 return;
-            //Set each players rock meter low enough that one missed note causes a fail.
-            switch (deathLinkType)
+            var type = GetDeathLinkSetting();
+            switch (type)
             {
                 case APData.DeathLinkType.Fail:
                     _ = CurrentSong.ForceSongFail();
                     break;
                 case APData.DeathLinkType.RockMeter:
+                    //Set each players rock meter low enough that one missed note causes a fail.
                     foreach (var player in CurrentSong.Players)
                     {
                         var EngineContainer = player.GetEngineContainer();

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -9,9 +9,11 @@ using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using YARG.Core.Extensions;
 using YARG.Gameplay;
 using YARG.Gameplay.Player;
 using YARG.Menu.Persistent;
+using static UnityEngine.Rendering.DebugUI;
 
 namespace YARG.Assets.Script.YargAP
 {
@@ -28,6 +30,7 @@ namespace YARG.Assets.Script.YargAP
         public static DeathLinkService deathLinkService;
         public static APData.DeathLinkType deathLinkType = APData.DeathLinkType.RockMeter;
         public static int deathLinkOverride = 0;
+        public static System.Random random = new System.Random();
         public static bool _isConnected => APEvents.session?.Socket != null && APEvents.session.Socket.Connected;
 
         public static HashSet<string> RecievedSongs = new HashSet<string>();
@@ -89,7 +92,7 @@ namespace YARG.Assets.Script.YargAP
         {
             if (message is Archipelago.MultiClient.Net.MessageLog.Messages.ChatLogMessage chatMessage && !PrintChatMessages)
                 return;
-            if (message is Archipelago.MultiClient.Net.MessageLog.Messages.ItemSendLogMessage itemMessage && !itemMessage.IsReceiverTheActivePlayer && !PrintUnrelatedItems)
+            if (message is Archipelago.MultiClient.Net.MessageLog.Messages.ItemSendLogMessage itemMessage && !itemMessage.IsReceiverTheActivePlayer && !itemMessage.IsSenderTheActivePlayer && !PrintUnrelatedItems)
                 return;
             ToastManager.ToastMessage(message.ToString());
         }
@@ -136,6 +139,7 @@ namespace YARG.Assets.Script.YargAP
             if (CurrentSong == null || deathLinkOverride == 1)
                 return;
             var type = GetDeathLinkSetting();
+            ToastManager.ToastError($"{deathLink.Source} {deathLink.Cause}");
             switch (type)
             {
                 case APData.DeathLinkType.Fail:
@@ -150,6 +154,22 @@ namespace YARG.Assets.Script.YargAP
                     }
                     break;
             }
+        }
+
+        public static string GetRandomDeatLinkMessage(GameManager game, List<BasePlayer> players)
+        {
+            List<string> AllMessages = new List<string>() { $"failed to play {game.Song.Name}" };
+            foreach (var message in APData.DeathLinkMessages)
+            {
+                foreach(var player in players)
+                {
+                    var Valid = message.Valid(player.Player.Profile.CurrentInstrument);
+                    if (Valid)
+                        AllMessages.Add(message.Message);
+                }
+            }
+            var Selected = AllMessages.PickRandom(random);
+            return Selected;
         }
     }
 }

--- a/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
+++ b/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
@@ -25,7 +25,10 @@ namespace YARG.Assets.Script.YargAP
         [SerializeField] private string slotName = "";
         [SerializeField] private string password = "";
 
-        private Rect _windowRect = new Rect(20, 20, 360, 250);
+        private string[] deathLinkOptions = { "yaml", "disabled", "instant", "one hit" };
+        private bool showDeathlinkDropdown = false;
+
+        private Rect _windowRect = new Rect(20, 20, 400, 260);
 
         private void Awake()
         {
@@ -45,11 +48,11 @@ namespace YARG.Assets.Script.YargAP
 
             _windowRect = GUI.Window(0xA1C4, _windowRect, DrawWindow, "Archipelago Connection");
         }
-
         private void DrawWindow(int id)
         {
-            GUILayout.BeginVertical();
+            GUILayout.BeginHorizontal();
 
+            GUILayout.BeginVertical(GUILayout.Width(180));
             GUILayout.Label("Address");
             using (new GUIEnabledScope(!APEvents._isConnected))
                 address = GUILayout.TextField(address);
@@ -63,7 +66,6 @@ namespace YARG.Assets.Script.YargAP
                 password = GUILayout.PasswordField(password, '*');
 
             GUILayout.Space(10);
-
             string buttonText = APEvents._isConnected ? "Disconnect" : "Connect";
             if (GUILayout.Button(buttonText, GUILayout.Height(28)))
             {
@@ -74,13 +76,42 @@ namespace YARG.Assets.Script.YargAP
                 else
                     DoConnect();
             }
+            GUILayout.EndVertical();
 
-            GUILayout.Space(6);
+            GUILayout.Space(20);
 
-            if (GUILayout.Button("Close"))
-                Show = false;
+            GUILayout.BeginVertical(GUILayout.Width(180));
+
+            GUILayout.Label("Death Link Override");
+
+            string statusText = APEvents._isConnected ? (APEvents.deathLinkService != null ? "Enabled by YAML" : "Disabled by YAML") : "Not Connected";
+            GUILayout.Label(statusText);
+
+            if (APEvents._isConnected && APEvents.deathLinkService != null)
+            {
+                if (GUILayout.Button(deathLinkOptions[APEvents.deathLinkOverride], GUILayout.Height(20)))
+                    showDeathlinkDropdown = !showDeathlinkDropdown;
+
+                if (showDeathlinkDropdown)
+                {
+                    for (int i = 0; i < deathLinkOptions.Length; i++)
+                    {
+                        if (GUILayout.Button(deathLinkOptions[i], GUILayout.Height(20)))
+                        {
+                            APEvents.deathLinkOverride = i;
+                            showDeathlinkDropdown = false;
+                        }
+                    }
+                }
+            }
 
             GUILayout.EndVertical();
+
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(6);
+            if (GUILayout.Button("Close"))
+                Show = false;
 
             GUI.DragWindow(new Rect(0, 0, 10000, 20));
         }

--- a/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
+++ b/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
@@ -84,28 +84,29 @@ namespace YARG.Assets.Script.YargAP
 
             GUILayout.Label("Deathlink Status");
 
-            string statusText = APEvents._isConnected ? (APEvents.deathLinkService != null ? "Enabled by YAML" : "Disabled by YAML") : "Not Connected";
+            string statusText = APEvents._isConnected ? (APEvents.deathLinkService != null ? "-Enabled by YAML" : "-Disabled by YAML") : "-Not Connected";
             GUILayout.Label(statusText);
 
             GUILayout.Label("Deathlink Setting Override");
 
-            if (APEvents._isConnected && APEvents.deathLinkService != null)
+            using (new GUIEnabledScope(APEvents._isConnected && APEvents.deathLinkService != null))
             {
                 if (GUILayout.Button(deathLinkOptions[APEvents.deathLinkOverride], GUILayout.Height(20)))
-                    showDeathlinkDropdown = !showDeathlinkDropdown;
-
-                if (showDeathlinkDropdown)
                 {
-                    for (int i = 0; i < deathLinkOptions.Length; i++)
-                    {
-                        if (GUILayout.Button(deathLinkOptions[i], GUILayout.Height(20)))
-                        {
-                            APEvents.deathLinkOverride = i;
-                            showDeathlinkDropdown = false;
-                        }
-                    }
+                    var NewVal = APEvents.deathLinkOverride + 1;
+                    if (NewVal >= deathLinkOptions.Length)
+                        NewVal = 0;
+                    APEvents.deathLinkOverride = NewVal;
                 }
             }
+
+            GUILayout.Label("Chat settings");
+
+            if (GUILayout.Button($"Print Chat Messages: {APEvents.PrintChatMessages}"))
+                APEvents.PrintChatMessages = !APEvents.PrintChatMessages;
+
+            if (GUILayout.Button($"Print Unrelated Items: {APEvents.PrintUnrelatedItems}"))
+                APEvents.PrintUnrelatedItems = !APEvents.PrintUnrelatedItems;
 
             GUILayout.EndVertical();
 
@@ -200,8 +201,7 @@ namespace YARG.Assets.Script.YargAP
                 APEvents.deathLinkService.EnableDeathLink();
                 APEvents.deathLinkService.OnDeathLinkReceived += APEvents.ProcessDeathLink;
                 APEvents.deathLinkType = DLI > 1 ? APData.DeathLinkType.Fail : APData.DeathLinkType.RockMeter;
-
-
+                
             }
 
             ToastManager.ToastInformation("Connected to Archipelago server successfully!");

--- a/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
+++ b/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
@@ -25,7 +25,7 @@ namespace YARG.Assets.Script.YargAP
         [SerializeField] private string slotName = "";
         [SerializeField] private string password = "";
 
-        private string[] deathLinkOptions = { "yaml", "disabled", "instant", "one hit" };
+        private string[] deathLinkOptions = { "use yaml", "disabled", "instant", "one hit" };
         private bool showDeathlinkDropdown = false;
 
         private Rect _windowRect = new Rect(20, 20, 400, 260);
@@ -82,10 +82,12 @@ namespace YARG.Assets.Script.YargAP
 
             GUILayout.BeginVertical(GUILayout.Width(180));
 
-            GUILayout.Label("Death Link Override");
+            GUILayout.Label("Deathlink Status");
 
             string statusText = APEvents._isConnected ? (APEvents.deathLinkService != null ? "Enabled by YAML" : "Disabled by YAML") : "Not Connected";
             GUILayout.Label(statusText);
+
+            GUILayout.Label("Deathlink Setting Override");
 
             if (APEvents._isConnected && APEvents.deathLinkService != null)
             {


### PR DESCRIPTION
-Add a deathlink override feature to change deathlink behavior after generation.
-Add random Death Link messages
-Add a custom header to show missing Yarg Gems and Goal song item dependent on view settings.
-Always print items sent by the current player as toasts
-Print death link player and cause as a toast
-Change the Deathlink override button behavior to just toggle through the values instead of showing a "dropdown"
-Add toggle buttons for Chat settings.