### PR TITLE
5 create archipelago menu

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
-    "files.exclude":
-    {
+    "files.exclude": {
         "**/.DS_Store": true,
         "**/.git": true,
         "**/*.meta": true,
@@ -11,5 +10,5 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "YARG.slnx"
+    "dotnet.defaultSolution": "YARGAPClient.slnx"
 }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -236,14 +236,14 @@ namespace YARG.Gameplay
         private bool HasShownGoalWarning = false;
         private void Update()
         {
-            if (!HasShownGoalWarning && APEvents.GoalSong == Song.Name && !APEvents.CanCompleteGoalSong() && !IsPractice)
+            if (APEvents.APGoalSong != null && !HasShownGoalWarning && APEvents.APGoalSong.MatchesSongEntry(Song) && !APEvents.APGoalSong.CanCompleteLocation() && !IsPractice)
             {
                 StringBuilder Error = new StringBuilder();
 
                 Error.AppendLine("You have selected your goal song but you do not have the items needed to complete it!");
-                if (APEvents.GoalItemNeeded > APEvents.GoalItemCount)
-                    Error.AppendLine($"\nYou have {APEvents.GoalItemCount} Gems, but you need {APEvents.GoalItemNeeded}!");
-                if (!APEvents.RecievedSongs.Contains(APEvents.GoalSong))
+                if (!APEvents.APGoalSong.HasEnoughYargGems())
+                    Error.AppendLine($"\nYou have {APEvents.APGoalSong.GoalItemCount} Gems, but you need {APEvents.APGoalSong.GoalItemNeeded}!");
+                if (!APEvents.APGoalSong.HasReceivedSong())
                     Error.AppendLine($"\nYou have not found your goal song item!");
 
                 SetPaused(!_pauseMenu.IsOpen);
@@ -743,9 +743,9 @@ namespace YARG.Gameplay
 
             if (!PlayerHasFailed)
             {
-                if (APEvents._isConnected && APEvents.deathLinkService != null && APEvents.deathLinkOverride != 1)
-                    APEvents.deathLinkService.SendDeathLink(new Archipelago.MultiClient.Net.BounceFeatures.DeathLink.DeathLink(
-                        APEvents.session.Players.ActivePlayer.Name, APEvents.GetRandomDeatLinkMessage(this, _players)));
+                if (APEvents.IsConnected && APEvents.DeathLinkService != null && APEvents.DeathLinkOverride != 1)
+                    APEvents.DeathLinkService.SendDeathLink(new Archipelago.MultiClient.Net.BounceFeatures.DeathLink.DeathLink(
+                        APEvents.Session.Players.ActivePlayer.Name, APEvents.GetRandomDeatLinkMessage(this, _players)));
                 await ForceSongFail();
             }
         }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -499,6 +499,7 @@ namespace YARG.Gameplay
 #nullable enable
             ReplayInfo? replayInfo = null;
 #nullable disable
+            /*
             try
             {
                 _isReplaySaved = false;
@@ -508,6 +509,7 @@ namespace YARG.Gameplay
             {
                 YargLogger.LogException(e, "Failed to save replay!");
             }
+            */
 
             // Pass the score info to the stats screen
             GlobalVariables.State.ScoreScreenStats = new ScoreScreenStats
@@ -533,6 +535,8 @@ namespace YARG.Gameplay
 
             if (!APCheckInvalid)
                 APEvents.TryCheckSongLocation(this);
+
+            APEvents.SendEnergy(BandScore);
 
             // Dispose the crowd handler
             CrowdEventHandler.Dispose();

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -536,7 +536,8 @@ namespace YARG.Gameplay
             if (!APCheckInvalid)
                 APEvents.TryCheckSongLocation(this);
 
-            APEvents.SendEnergy(BandScore);
+            if (APEvents.EnergyLinkType > APData.EnergyLinkType.DISABLED)
+                APEvents.SendEnergy(BandScore);
 
             // Dispose the crowd handler
             CrowdEventHandler.Dispose();

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -747,7 +747,7 @@ namespace YARG.Gameplay
 
             if (!PlayerHasFailed)
             {
-                if (APEvents.IsConnected && APEvents.DeathLinkService != null && APEvents.DeathLinkOverride != 1)
+                if (APEvents.IsConnected && APEvents.DeathLinkService != null && APEvents.DeathLinkType > 0)
                     APEvents.DeathLinkService.SendDeathLink(new Archipelago.MultiClient.Net.BounceFeatures.DeathLink.DeathLink(
                         APEvents.Session.Players.ActivePlayer.Name, APEvents.GetRandomDeatLinkMessage(this, _players)));
                 await ForceSongFail();

--- a/Assets/Script/Menu/Archipelago/ArchipelagoMenu.cs
+++ b/Assets/Script/Menu/Archipelago/ArchipelagoMenu.cs
@@ -53,9 +53,9 @@ namespace YARG.Menu.ArchipelagoMenu
         {
             APEvents.PrintChatMessages = PrintChat.isOn;
             APEvents.PrintUnrelatedItems = PrintUnrelatedItems.isOn;
-            APEvents.deathLinkOverride = DeathLinkMode.value;
+            APEvents.DeathLinkOverride = DeathLinkMode.value;
 
-            Debug.Log($"{APEvents.PrintChatMessages} | {APEvents.PrintUnrelatedItems} | {APEvents.deathLinkOverride}");
+            Debug.Log($"{APEvents.PrintChatMessages} | {APEvents.PrintUnrelatedItems} | {APEvents.DeathLinkOverride}");
         }
 
         private void OnDisable()

--- a/Assets/Script/Menu/Archipelago/ArchipelagoMenu.cs
+++ b/Assets/Script/Menu/Archipelago/ArchipelagoMenu.cs
@@ -53,9 +53,10 @@ namespace YARG.Menu.ArchipelagoMenu
         {
             APEvents.PrintChatMessages = PrintChat.isOn;
             APEvents.PrintUnrelatedItems = PrintUnrelatedItems.isOn;
-            APEvents.DeathLinkOverride = DeathLinkMode.value;
+            APEvents.DeathLinkType = DeathLinkMode.value >= APData.DeathLinkValues.Length ? APEvents.DeathLinkYAML : APData.DeathLinkValues[DeathLinkMode.value];
+            APEvents.UpdateDeathLinkTag();
 
-            Debug.Log($"{APEvents.PrintChatMessages} | {APEvents.PrintUnrelatedItems} | {APEvents.DeathLinkOverride}");
+            Debug.Log($"{APEvents.PrintChatMessages} | {APEvents.PrintUnrelatedItems} | {APEvents.DeathLinkType}");
         }
 
         private void OnDisable()

--- a/Assets/Script/Menu/Main/MainMenu.cs
+++ b/Assets/Script/Menu/Main/MainMenu.cs
@@ -103,7 +103,8 @@ namespace YARG.Menu.Main
 
         public void Archipelago()
         {
-            MenuManager.Instance.PushMenu(MenuManager.Menu.Archipelago);
+            //MenuManager.Instance.PushMenu(MenuManager.Menu.Archipelago);
+            ToggleArchipelagoDialog();
         }
 
         public void Exit()

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -465,29 +465,23 @@ namespace YARG.Menu.MusicLibrary
                     list.Add(new CategoryViewType(
                         Localize.Key("Menu.MusicLibrary.AllSongs"), songCount, SongContainer.Songs));
 
-                    var AvailableSongs = APEvents.GetUnplayedAvailableLocations();
-                    var HasGoalSong = AvailableSongs.Remove(APEvents.GoalSong);
-                    var HasGoalItems = APEvents.GoalItemCount >= APEvents.GoalItemNeeded;
-                    var ShouldDisplayGoalSong =
-                        APEvents.goalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
-                        (HasGoalSong && APEvents.goalDisplaySetting == APData.GoalDisplaySetting.song) ||
-                        (HasGoalItems && APEvents.goalDisplaySetting == APData.GoalDisplaySetting.gems) ||
-                        (HasGoalSong && HasGoalItems && APEvents.goalDisplaySetting == APData.GoalDisplaySetting.both);
+                    var AvailableSongs = APEvents.APSongLocations.Where(x => x.VisibleInSongList()).ToArray();
+                    var ShouldDisplayGoalSong = APEvents.APGoalSong?.VisibleInSongList() ?? false;
 
                     if (ShouldDisplayGoalSong)
                     {
-                        if (APEvents.goalDisplaySetting == APData.GoalDisplaySetting.song ||
-                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
-                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.both)
-                            list.Add(new CategoryViewType($"Gems {APEvents.GoalItemCount}\\{APEvents.GoalItemNeeded}", 0, new SongEntry[0], RefreshAndReselect));
+                        if (APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.song ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.both)
+                            list.Add(new CategoryViewType($"Gems {APEvents.APGoalSong?.GoalItemCount}\\{APEvents.APGoalSong?.GoalItemNeeded}", 0, new SongEntry[0], RefreshAndReselect));
 
-                        if (APEvents.goalDisplaySetting == APData.GoalDisplaySetting.gems ||
-                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
-                            APEvents.goalDisplaySetting == APData.GoalDisplaySetting.both)
-                            list.Add(new CategoryViewType($"Goal Song Item: {(HasGoalSong ? "Found" : "Missing")}", 0, new SongEntry[0], RefreshAndReselect));
+                        if (APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.gems ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.both)
+                            list.Add(new CategoryViewType($"Goal Song Item: {(APEvents.APGoalSong?.HasReceivedSong()??false ? "Found" : "Missing")}", 0, new SongEntry[0], RefreshAndReselect));
                     }
 
-                    var GoalSong = SongContainer.Songs.FirstOrDefault(x => x.Name == APEvents.GoalSong);
+                    var GoalSong = APEvents.APGoalSong?.GetYargSongEntry();
                     if (GoalSong == null)
                         ShouldDisplayGoalSong = false;
 
@@ -497,22 +491,21 @@ namespace YARG.Menu.MusicLibrary
                         list.Add(new SongViewType(this, GoalSong));
                     }
 
-                    if (AvailableSongs.Count > 0)
+                    if (AvailableSongs.Any())
                     {
-                        Debug.Log(string.Join("|", AvailableSongs));
-                        var AvailableAPSongs = new List<SongEntry>();
+                        var availableAPSongs = new List<SongEntry>();
                         foreach (var APSong in AvailableSongs)
                         {
-                            var Song = SongContainer.Songs.FirstOrDefault(x => x.Name == APSong);
-                            if (Song != null)
-                                AvailableAPSongs.Add(Song);
+                            var song = APSong.GetYargSongEntry();
+                            if (song != null)
+                                availableAPSongs.Add(song);
                             else
                                 ToastManager.ToastError($"Failed to find song with song hash {APSong}!\nEnsure you are using the YARG official setlist!");
                         }
-                        if (AvailableAPSongs.Count > 0)
+                        if (availableAPSongs.Count > 0)
                         {
-                            list.Add(new CategoryViewType("AP Songs", AvailableAPSongs.Count, AvailableAPSongs.ToArray(), RefreshAndReselect));
-                            foreach (var song in AvailableAPSongs)
+                            list.Add(new CategoryViewType("AP Songs", availableAPSongs.Count, availableAPSongs.ToArray(), RefreshAndReselect));
+                            foreach (var song in availableAPSongs)
                                 list.Add(new SongViewType(this, song));
                         }
                     }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -470,14 +470,14 @@ namespace YARG.Menu.MusicLibrary
 
                     if (ShouldDisplayGoalSong)
                     {
-                        if (APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.song ||
-                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
-                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.both)
+                        if (APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.SONG ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.FULL ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.BOTH)
                             list.Add(new CategoryViewType($"Gems {APEvents.APGoalSong?.GoalItemCount}\\{APEvents.APGoalSong?.GoalItemNeeded}", 0, new SongEntry[0], RefreshAndReselect));
 
-                        if (APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.gems ||
-                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
-                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.both)
+                        if (APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.GEMS ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.FULL ||
+                            APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.BOTH)
                             list.Add(new CategoryViewType($"Goal Song Item: {(APEvents.APGoalSong?.HasReceivedSong()??false ? "Found" : "Missing")}", 0, new SongEntry[0], RefreshAndReselect));
                     }
 

--- a/Assets/Script/Song/SongExport.cs
+++ b/Assets/Script/Song/SongExport.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Newtonsoft.Json;
+using UnityEngine.InputSystem;
 using YARG.Core.Song;
 using YARG.Core.Utility;
 
@@ -69,37 +71,40 @@ namespace YARG.Song
         {
             var songs = new List<OuvertSongData>();
 
+            var SelectedFolder = Path.GetDirectoryName(path);
+            var Devjson = Path.Join(SelectedFolder, "SongData.json");
+            var pyFormatted = Path.Join(SelectedFolder, "SongDictTemplate.txt");
+
+            StringBuilder PythonFile = new StringBuilder();
+            PythonFile.AppendLine("Songs: Dict[str, SongMeta] = {");
+
             // Convert SongInfo to OuvertSongData
             foreach (var song in SongContainer.Songs)
             {
-                if(RichTextUtils.StripRichTextTags(song.Playlist) == "Unknown Playlist")
+                songs.Add(new OuvertSongData
                 {
-                    songs.Add(new OuvertSongData
-                    {
-                        songName = RichTextUtils.StripRichTextTags(song.Name),
-                        artistName = RichTextUtils.StripRichTextTags(song.Artist),
-                        album = RichTextUtils.StripRichTextTags(song.Album),
-                        genre = RichTextUtils.StripRichTextTags(song.Genre),
-                        charter = RichTextUtils.StripRichTextTags(song.Charter),
-                        year = RichTextUtils.StripRichTextTags(song.UnmodifiedYear),
-                        songLength = (ulong)song.SongLengthMilliseconds
-                    });
-                }
-                else
+                    songName = RichTextUtils.StripRichTextTags(song.Name),
+                    artistName = RichTextUtils.StripRichTextTags(song.Artist),
+                    album = RichTextUtils.StripRichTextTags(song.Album),
+                    playlist = RichTextUtils.StripRichTextTags(song.Playlist) == "Unknown Playlist" ? null : RichTextUtils.StripRichTextTags(song.Playlist),
+                    genre = RichTextUtils.StripRichTextTags(song.Genre),
+                    charter = RichTextUtils.StripRichTextTags(song.Charter),
+                    year = RichTextUtils.StripRichTextTags(song.UnmodifiedYear),
+                    songLength = (ulong)song.SongLengthMilliseconds
+                });
+
+                PythonFile.Append("    ").Append('"').Append(song.Name).Append('"').Append(": SongMeta(")
+                    .Append('"').Append(song.Source.Original).Append('"').Append(", ")
+                    .Append('"').Append(song.Source.Original).Append('"').Append(", ");
+                for (var i = 0; i < 10; i++)
                 {
-                    songs.Add(new OuvertSongData
-                    {
-                        songName = RichTextUtils.StripRichTextTags(song.Name),
-                        artistName = RichTextUtils.StripRichTextTags(song.Artist),
-                        album = RichTextUtils.StripRichTextTags(song.Album),
-                        playlist = RichTextUtils.StripRichTextTags(song.Playlist),
-                        genre = RichTextUtils.StripRichTextTags(song.Genre),
-                        charter = RichTextUtils.StripRichTextTags(song.Charter),
-                        year = RichTextUtils.StripRichTextTags(song.UnmodifiedYear),
-                        songLength = (ulong)song.SongLengthMilliseconds
-                    });
+                    PythonFile.Append(" None");
+                        if (i == 9)
+                            PythonFile.Append(',');
                 }
+                PythonFile.AppendLine("),");
             }
+            PythonFile.Append('}');
 
             // Create file
             var json = JsonConvert.SerializeObject(songs, Formatting.Indented, new JsonSerializerSettings
@@ -107,6 +112,11 @@ namespace YARG.Song
                 NullValueHandling = NullValueHandling.Ignore
             });
             File.WriteAllText(path, json);
+            File.WriteAllText(pyFormatted, PythonFile.ToString());
+            File.WriteAllText(Devjson, JsonConvert.SerializeObject(SongContainer.Songs, Formatting.Indented, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            }));
         }
     }
 }

--- a/Assets/Script/YargAP/APConnectionHelper.cs
+++ b/Assets/Script/YargAP/APConnectionHelper.cs
@@ -5,11 +5,14 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine;
+using YARG.Helpers;
 using YARG.Menu.Persistent;
 using YARG.Song;
 using Object = System.Object;
@@ -66,15 +69,16 @@ namespace YARG.Assets.Script.YargAP
             }
 
             List<APData.APSongLocation> APSongLocations = new List<APData.APSongLocation>();
+            APData.APGoalSong APGoalSong = null;
             var BadSongs = new List<APData.APSongData>();
             foreach (var song in ((JObject)SlotDataSongList!).ToObject<Dictionary<string, object[]>>())
             {
                 if (song.Key == (string) SlotDataGoalSong && (string) song.Value[3] == (string) SlotDataGoalSongSource)
                 {
-                    APEvents.APGoalSong = new APData.APGoalSong(song.Key, (string) song.Value[3], (long) song.Value[2], (int) (long) SlotDataGemsRequired!);
-                    APEvents.APGoalSong?.UpdateGoalItems();
-                    if (SongContainer.Songs.All(x => !APEvents.APGoalSong.MatchesSongEntry(x)))
-                        BadSongs.Add(APEvents.APGoalSong);
+                    APGoalSong = new APData.APGoalSong(song.Key, (string) song.Value[3], (long) song.Value[2], (int) (long) SlotDataGemsRequired!);
+                    APGoalSong.UpdateGoalItems();
+                    if (SongContainer.Songs.All(x => !APGoalSong.MatchesSongEntry(x)))
+                        BadSongs.Add(APGoalSong);
                     continue;
                 }
 
@@ -86,7 +90,7 @@ namespace YARG.Assets.Script.YargAP
                     BadSongs.Add(songLocation);
             }
 
-            if (APEvents.APGoalSong is null)
+            if (APGoalSong is null)
             {
                 DoDisconnect(true, $"Connection Failed:\nFailed to find Goal song [{SlotDataGoalSongSource}] {SlotDataGoalSong} in APSongList");
                 return;
@@ -101,21 +105,21 @@ namespace YARG.Assets.Script.YargAP
                     $"The following songs were included in your seed but were not found in YARG:\n\n{badList}");
             }
             APEvents.APSongLocations = APSongLocations.ToArray();
+            APEvents.APGoalSong = APGoalSong;
             APEvents.GoalDisplaySetting = (APData.GoalDisplaySetting) (long) SlotDataGoalSongVisibility!;
+            APEvents.DeathLinkType = (APData.DeathLinkType) (long) SlotDataDeathLink;
+            APEvents.DeathLinkYAML = (APData.DeathLinkType) (long) SlotDataDeathLink;
+            APEvents.DeathLinkService = APEvents.Session.CreateDeathLinkService();
 
             APEvents.Session.MessageLog.OnMessageReceived += APEvents.MessageLog_OnMessageReceived;
             APEvents.Session.Items.ItemReceived += APEvents.Items_ItemReceived;
+            APEvents.DeathLinkService.OnDeathLinkReceived += APEvents.ProcessDeathLink;
 
-            if ((long)SlotDataDeathLink > 0)
-            {
-                APEvents.DeathLinkService = DeathLinkProvider.CreateDeathLinkService(APEvents.Session);
-                APEvents.DeathLinkService.EnableDeathLink();
-                APEvents.DeathLinkService.OnDeathLinkReceived += APEvents.ProcessDeathLink;
-                APEvents.DeathLinkType = (long)SlotDataDeathLink  > 1 ? APData.DeathLinkType.Fail : APData.DeathLinkType.RockMeter;
+            APEvents.UpdateDeathLinkTag();
 
-            }
+            SaveConnectionCache(APEvents.Session, Password);
+
             ToastManager.ToastInformation("Connected to Archipelago server successfully!");
-
         }
 
         public static void DoDisconnect(bool Early = false, string ErrorMessage = null)
@@ -123,16 +127,52 @@ namespace YARG.Assets.Script.YargAP
             if (APEvents.IsConnected)
                 APEvents.Session.Socket.DisconnectAsync();
 
+            if (!Early)
+            {
+                APEvents.Session.MessageLog.OnMessageReceived -= APEvents.MessageLog_OnMessageReceived;
+                APEvents.Session.Items.ItemReceived -= APEvents.Items_ItemReceived;
+                APEvents.DeathLinkService.OnDeathLinkReceived -= APEvents.ProcessDeathLink;
+            }
+
+            APEvents.Session = null;
             APEvents.APGoalSong = null;
             APEvents.DeathLinkService = null;
             APEvents.APSongLocations = Array.Empty<APData.APSongLocation>();
-            if (Early) return;
-            APEvents.Session.MessageLog.OnMessageReceived -= APEvents.MessageLog_OnMessageReceived;
-            APEvents.Session.Items.ItemReceived -= APEvents.Items_ItemReceived;
+
             if (ErrorMessage is null)
                 ToastManager.ToastInformation("Disconnected from Archipelago!");
             else
                 ToastManager.ToastError(ErrorMessage);
+        }
+
+        private static string ConnectionCachePath = Path.Combine(PathHelper.PersistentDataPath, "APConnectionCache.json");
+        public static void SaveConnectionCache(ArchipelagoSession session, string password)
+        {
+            if (session is null || !session.Socket.Connected) return;
+            APData.ConnectionCache Cache = new APData.ConnectionCache()
+            {
+                IP = session.Socket.Uri.Host,
+                Port = session.Socket.Uri.Port,
+                SlotName = session.Players.ActivePlayer.Name,
+                Password = password,
+            };
+            File.WriteAllText(ConnectionCachePath, JsonUtility.ToJson(Cache));
+            Debug.Log($"Saved Connection Cache to {ConnectionCachePath}\n{JsonConvert.SerializeObject(Cache, Formatting.Indented)}");
+        }
+
+        public static APData.ConnectionCache LoadConnectionCache()
+        {
+            if (!File.Exists(ConnectionCachePath)) return null;
+            try
+            {
+                var content = File.ReadAllText(ConnectionCachePath);
+                return JsonUtility.FromJson<APData.ConnectionCache>(content);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return null;
+            }
         }
     }
 }

--- a/Assets/Script/YargAP/APConnectionHelper.cs
+++ b/Assets/Script/YargAP/APConnectionHelper.cs
@@ -41,6 +41,7 @@ namespace YARG.Assets.Script.YargAP
             object SlotDataSongList;
             object SlotDataGoalSongVisibility;
             object SlotDataDeathLink;
+            object SlotDataEnergyLink;
 
             string ConnectionError = null;
 
@@ -61,6 +62,9 @@ namespace YARG.Assets.Script.YargAP
 
             if (!SlotData.TryGetValue("Death Link", out SlotDataDeathLink) || SlotDataDeathLink is not long)
                 ConnectionError = "Death Link could not be parsed from slot data";
+
+            if (!SlotData.TryGetValue("Energy Link", out SlotDataEnergyLink) || SlotDataEnergyLink is not long)
+                ConnectionError = "Energy Link could not be parsed from slot data";
 
             if (ConnectionError is not null)
             {
@@ -109,6 +113,8 @@ namespace YARG.Assets.Script.YargAP
             APEvents.GoalDisplaySetting = (APData.GoalDisplaySetting) (long) SlotDataGoalSongVisibility!;
             APEvents.DeathLinkType = (APData.DeathLinkType) (long) SlotDataDeathLink;
             APEvents.DeathLinkYAML = (APData.DeathLinkType) (long) SlotDataDeathLink;
+            APEvents.EnergyLinkType = (APData.EnergyLinkType) (long) SlotDataEnergyLink;
+            APEvents.EnergyLinkYAML = (APData.EnergyLinkType) (long) SlotDataEnergyLink;
             APEvents.DeathLinkService = APEvents.Session.CreateDeathLinkService();
 
             APEvents.Session.MessageLog.OnMessageReceived += APEvents.MessageLog_OnMessageReceived;

--- a/Assets/Script/YargAP/APConnectionHelper.cs
+++ b/Assets/Script/YargAP/APConnectionHelper.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using YARG.Helpers;
 using YARG.Menu.Persistent;

--- a/Assets/Script/YargAP/APConnectionHelper.cs
+++ b/Assets/Script/YargAP/APConnectionHelper.cs
@@ -12,6 +12,7 @@ using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using YARG.Menu.Persistent;
 using YARG.Song;
+using Object = System.Object;
 
 namespace YARG.Assets.Script.YargAP
 {
@@ -19,107 +20,119 @@ namespace YARG.Assets.Script.YargAP
     {
         public static void DoConnect(string ServerAddress, string slotName, string Password)
         {
-            if (APEvents._isConnected) return;
-            APEvents.session = ArchipelagoSessionFactory.CreateSession(ServerAddress);
-            var Result = APEvents.session.TryConnectAndLogin("YARG", slotName, Archipelago.MultiClient.Net.Enums.ItemsHandlingFlags.AllItems, password: Password);
+            if (APEvents.IsConnected) return;
+            APEvents.Session = ArchipelagoSessionFactory.CreateSession(ServerAddress);
+            var Result = APEvents.Session.TryConnectAndLogin("YARG", slotName, Archipelago.MultiClient.Net.Enums.ItemsHandlingFlags.AllItems, password: Password);
             if (Result is LoginFailure failure)
             {
                 ToastManager.ToastError("Failed to connect to Archipelago server: " + string.Join(Environment.NewLine, failure.Errors));
-                APEvents.session = null;
+                APEvents.Session = null;
                 return;
             }
 
-            var SlotData = APEvents.session.DataStorage.GetSlotData();
+            var SlotData = APEvents.Session.DataStorage.GetSlotData();
 
-            if (SlotData.ContainsKey("songlist"))
+            object SlotDataGoalSong;
+            object SlotDataGoalSongSource;
+            object SlotDataGemsRequired;
+            object SlotDataSongList;
+            object SlotDataGoalSongVisibility;
+            object SlotDataDeathLink;
+
+            string ConnectionError = null;
+
+            if (!SlotData.TryGetValue("Goal Song", out SlotDataGoalSong) || SlotDataGoalSong is not string)
+                ConnectionError = "Goal Song could not be parsed from slot data";
+
+            if (!SlotData.TryGetValue("Goal Song Source", out SlotDataGoalSongSource) || SlotDataGoalSongSource is not string)
+                ConnectionError = "Goal Song source could not be parsed from slot data";
+
+            if (!SlotData.TryGetValue("Gems Required", out SlotDataGemsRequired) || SlotDataGemsRequired is not long)
+                ConnectionError = "Required Gems could not be parsed from slot data";
+
+            if (!SlotData.TryGetValue("songlist", out SlotDataSongList) || SlotDataSongList is not JObject)
+                ConnectionError = "Song Data could not be parsed from slot data";
+
+            if (!SlotData.TryGetValue("Goal Song Visibility", out SlotDataGoalSongVisibility) || SlotDataGoalSongVisibility is not long)
+                ConnectionError = "Goal Song Visibility could not be parsed from slot data";
+
+            if (!SlotData.TryGetValue("Death Link", out SlotDataDeathLink) || SlotDataDeathLink is not long)
+                ConnectionError = "Death Link could not be parsed from slot data";
+
+            if (ConnectionError is not null)
             {
-                var songlistObj = (JObject) SlotData["songlist"];
-                APData.SongNames = songlistObj.ToObject<Dictionary<string, int[]>>();
-                APData.NeedsRegen = true;
-            }
-            else
-            {
-                ToastManager.ToastError($"Unable to parse song list. Report this to the APworld Devs!");
-                Debug.LogError($"Unable to parse song list {JsonConvert.SerializeObject(SlotData)}");
-                APEvents.session.Socket.DisconnectAsync();
-                APEvents.session = null;
+                DoDisconnect(true, $"Connection Failed:\n{ConnectionError}");
                 return;
             }
 
-            bool WasMissingSong = false;
-            foreach (var i in APData.SongNames)
-                if (!SongContainer.Songs.Any(x => x.Name == i.Key))
+            List<APData.APSongLocation> APSongLocations = new List<APData.APSongLocation>();
+            var BadSongs = new List<APData.APSongData>();
+            foreach (var song in ((JObject)SlotDataSongList!).ToObject<Dictionary<string, object[]>>())
+            {
+                if (song.Key == (string) SlotDataGoalSong && (string) song.Value[3] == (string) SlotDataGoalSongSource)
                 {
-                    WasMissingSong = true;
-                    Debug.LogError($"{i.Key} Was not found in the current yarg song list");
+                    APEvents.APGoalSong = new APData.APGoalSong(song.Key, (string) song.Value[3], (long) song.Value[2], (int) (long) SlotDataGemsRequired!);
+                    APEvents.APGoalSong?.UpdateGoalItems();
+                    if (SongContainer.Songs.All(x => !APEvents.APGoalSong.MatchesSongEntry(x)))
+                        BadSongs.Add(APEvents.APGoalSong);
+                    continue;
                 }
 
-            if (WasMissingSong)
-                DialogManager.Instance.ShowMessage("Missing Song Error", "One or more songs were not found in your YARG setlist\nEnsure you are using the YARG official setlist!");
+                var songLocation = new APData.APSongLocation(song.Key, (string) song.Value[3], (long) song.Value[0],
+                    (long) song.Value[1], (long) song.Value[2]);
+                APSongLocations.Add(songLocation);
 
-
-            if (SlotData["Goal Song"] is string GoalSongName && APData.SongNames.ContainsKey(GoalSongName))
-            {
-                Debug.Log($"Goal Song {GoalSongName}");
-                APEvents.GoalSong = GoalSongName;
+                if (SongContainer.Songs.All(x => !songLocation.MatchesSongEntry(x)))
+                    BadSongs.Add(songLocation);
             }
-            else
+
+            if (APEvents.APGoalSong is null)
             {
-                ToastManager.ToastError($"Could not get Goal Song. Report this to the APworld Devs!");
-                Debug.LogError($"Could not get Goal Song {JsonConvert.SerializeObject(SlotData)}");
-                APEvents.session.Socket.DisconnectAsync();
-                APEvents.session = null;
+                DoDisconnect(true, $"Connection Failed:\nFailed to find Goal song [{SlotDataGoalSongSource}] {SlotDataGoalSong} in APSongList");
                 return;
             }
 
-            if (SlotData["Gems Required"] is long GoalItemsNeeded)
+            if (BadSongs.Count > 0)
             {
-                Debug.Log($"Gems Needed {GoalItemsNeeded}");
-                APEvents.GoalItemNeeded = (int) GoalItemsNeeded;
+                var badList = string.Join(" | ",
+                    BadSongs.OrderBy(x => x.SongSource).ThenBy(x => x.SongName)
+                        .Select(x => $"[{x.SongSource}] {x.SongName}"));
+                DialogManager.Instance.ShowMessage("ERROR: Missing Songs!",
+                    $"The following songs were included in your seed but were not found in YARG:\n\n{badList}");
             }
-            else
-            {
-                ToastManager.ToastError($"Could not get Goal Item Requirement. Report this to the APworld Devs!");
-                Debug.LogError($"Could not get Goal Song {JsonConvert.SerializeObject(SlotData)}");
-                APEvents.session.Socket.DisconnectAsync();
-                APEvents.session = null;
-                return;
-            }
+            APEvents.APSongLocations = APSongLocations.ToArray();
+            APEvents.GoalDisplaySetting = (APData.GoalDisplaySetting) (long) SlotDataGoalSongVisibility!;
 
-            if (SlotData.TryGetValue("Goal Song Visibility", out var GSV) && GSV is Int64 VI)
-            {
-                APEvents.goalDisplaySetting = (APData.GoalDisplaySetting) VI;
-            }
+            APEvents.Session.MessageLog.OnMessageReceived += APEvents.MessageLog_OnMessageReceived;
+            APEvents.Session.Items.ItemReceived += APEvents.Items_ItemReceived;
 
-            APEvents.session.MessageLog.OnMessageReceived += APEvents.MessageLog_OnMessageReceived;
-            APEvents.session.Items.ItemReceived += APEvents.Items_ItemReceived;
-
-            if (SlotData.TryGetValue("Death Link", out var DLO) && DLO is long DLI && DLI > 0)
+            if ((long)SlotDataDeathLink > 0)
             {
-                APEvents.deathLinkService = DeathLinkProvider.CreateDeathLinkService(APEvents.session);
-                APEvents.deathLinkService.EnableDeathLink();
-                APEvents.deathLinkService.OnDeathLinkReceived += APEvents.ProcessDeathLink;
-                APEvents.deathLinkType = DLI > 1 ? APData.DeathLinkType.Fail : APData.DeathLinkType.RockMeter;
+                APEvents.DeathLinkService = DeathLinkProvider.CreateDeathLinkService(APEvents.Session);
+                APEvents.DeathLinkService.EnableDeathLink();
+                APEvents.DeathLinkService.OnDeathLinkReceived += APEvents.ProcessDeathLink;
+                APEvents.DeathLinkType = (long)SlotDataDeathLink  > 1 ? APData.DeathLinkType.Fail : APData.DeathLinkType.RockMeter;
 
             }
-
             ToastManager.ToastInformation("Connected to Archipelago server successfully!");
 
-            APEvents.UpdateRecievedSongs();
         }
 
-        public static void DoDisconnect()
+        public static void DoDisconnect(bool Early = false, string ErrorMessage = null)
         {
-            if (APEvents._isConnected)
-                APEvents.session.Socket.DisconnectAsync();
+            if (APEvents.IsConnected)
+                APEvents.Session.Socket.DisconnectAsync();
 
-            APEvents.session.MessageLog.OnMessageReceived -= APEvents.MessageLog_OnMessageReceived;
-            APEvents.session.Items.ItemReceived -= APEvents.Items_ItemReceived;
-            APEvents.GoalSong = null;
-            APEvents.deathLinkService = null;
-            APData.SongNames = new Dictionary<string, int[]>();
-            APData.NeedsRegen = true;
-            ToastManager.ToastInformation("Disconnected from Archipelago!");
+            APEvents.APGoalSong = null;
+            APEvents.DeathLinkService = null;
+            APEvents.APSongLocations = Array.Empty<APData.APSongLocation>();
+            if (Early) return;
+            APEvents.Session.MessageLog.OnMessageReceived -= APEvents.MessageLog_OnMessageReceived;
+            APEvents.Session.Items.ItemReceived -= APEvents.Items_ItemReceived;
+            if (ErrorMessage is null)
+                ToastManager.ToastInformation("Disconnected from Archipelago!");
+            else
+                ToastManager.ToastError(ErrorMessage);
         }
     }
 }

--- a/Assets/Script/YargAP/APData.cs
+++ b/Assets/Script/YargAP/APData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -56,10 +57,10 @@ namespace YARG.Assets.Script.YargAP
             public override bool CanCompleteLocation() => HasReceivedSong() && HasEnoughYargGems();
 
             public override bool VisibleInSongList() =>
-                APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
-                (HasReceivedSong() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.song) ||
-                (HasEnoughYargGems() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.gems) ||
-                (HasReceivedSong() && HasEnoughYargGems() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.both);
+                APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.FULL ||
+                (HasReceivedSong() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.SONG) ||
+                (HasEnoughYargGems() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.GEMS) ||
+                (HasReceivedSong() && HasEnoughYargGems() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.BOTH);
         }
         public class APSongLocation : APSongData
         {
@@ -78,6 +79,14 @@ namespace YARG.Assets.Script.YargAP
                 APEvents.Session.Locations.AllLocationsChecked.Contains(LocationID2);
             public override bool VisibleInSongList() => HasReceivedSong() && !HasCheckedBothLocations();
             public override bool CanCompleteLocation() => HasReceivedSong() && !HasCheckedBothLocations();
+        }
+
+        public class ConnectionCache
+        {
+            public string IP;
+            public int    Port;
+            public string SlotName;
+            public string Password;
         }
 
         public static List<DeathLinkMessage> DeathLinkMessages = new()
@@ -103,23 +112,43 @@ namespace YARG.Assets.Script.YargAP
             public bool Valid(Instrument instrument) => InstrumentTags.Count == 0 || InstrumentTags.Contains(instrument);
         }
 
+        public static string GetDescription(this Enum value)
+        {
+            var field = value.GetType().GetField(value.ToString());
+            var attribute = (DescriptionAttribute)Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute));
+            return attribute?.Description ?? value.ToString();
+        }
+
         public enum APFiller
         {
             YargGem = 1,
             StarPower = 2
         }
+        public static APData.DeathLinkType[] DeathLinkValues = Enum.GetValues(typeof(APData.DeathLinkType)).Cast<APData.DeathLinkType>().ToArray();
         public enum DeathLinkType
         {
-            Fail = 1,
-            RockMeter = 2
+            [Description("Disabled")]
+            DISABLED  = 0,
+            [Description("One Hit")]
+            ONE_HIT = 1,
+            [Description("Instant")]
+            INSTANT = 2
+        }
+        public static APData.EnergyLinkType[] EnergyLinkValues = Enum.GetValues(typeof(APData.EnergyLinkType)).Cast<APData.EnergyLinkType>().ToArray();
+        public enum EnergyLinkType
+        {
+            [Description("Disabled")]
+            DISABLED = 0,
+            [Description("Enabled")]
+            ENABLED  = 1
         }
 
         public enum GoalDisplaySetting
         {
-            alwaysvisible = 0,
-            song = 1,
-            gems = 2,
-            both = 3
+            FULL = 0,
+            SONG = 1,
+            GEMS = 2,
+            BOTH = 3
         }
     }
 }

--- a/Assets/Script/YargAP/APData.cs
+++ b/Assets/Script/YargAP/APData.cs
@@ -3,12 +3,83 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
+using JetBrains.Annotations;
 using YARG.Core;
+using YARG.Core.Song;
+using YARG.Gameplay;
+using YARG.Song;
 
 namespace YARG.Assets.Script.YargAP
 {
-    internal class APData
+    internal static class APData
     {
+        public abstract class APSongData
+        {
+            public string SongName;
+            public string SongSource;
+            public long   ItemID;
+            public SongEntry GetYargSongEntry() => SongContainer.Songs.FirstOrDefault(x => x.Name == SongName && x.Source.Original == SongSource);
+            public bool HasReceivedSong() => APEvents.IsConnected &&
+                APEvents.Session.Items.AllItemsReceived.Any(x => x.ItemId == ItemID);
+
+            public bool MatchesSongEntry(SongEntry entry) => SongName == entry.Name && SongSource == entry.Source.Original;
+
+            public abstract bool CanCompleteLocation();
+
+            public abstract bool VisibleInSongList();
+
+            public bool MetPlayRequirements(GameManager gameManager)
+            {
+                //TODO when this is added
+                return true;
+            }
+        }
+
+        public class APGoalSong : APSongData
+        {
+            public APGoalSong(string name, string source, long itemID, int goalItemNeeded)
+            {
+                SongName = name;
+                SongSource = source;
+                ItemID = itemID;
+                GoalItemNeeded =  goalItemNeeded;
+            }
+            public int GoalItemCount  { get; private set; }  = 0;
+            public int GoalItemNeeded { get; }
+            public bool HasEnoughYargGems() => GoalItemCount >= GoalItemNeeded;
+
+            public void UpdateGoalItems() =>
+                GoalItemCount = APEvents.IsConnected
+                    ? APEvents.Session.Items.AllItemsReceived.Count(x => x.ItemId == (long) APData.APFiller.YargGem)
+                    : 0;
+            public override bool CanCompleteLocation() => HasReceivedSong() && HasEnoughYargGems();
+
+            public override bool VisibleInSongList() =>
+                APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.alwaysvisible ||
+                (HasReceivedSong() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.song) ||
+                (HasEnoughYargGems() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.gems) ||
+                (HasReceivedSong() && HasEnoughYargGems() && APEvents.GoalDisplaySetting == APData.GoalDisplaySetting.both);
+        }
+        public class APSongLocation : APSongData
+        {
+            public APSongLocation(string name, string source, long loc1ID, long loc2ID, long itemID)
+            {
+                SongName = name;
+                SongSource = source;
+                ItemID = itemID;
+                LocationID1 = loc1ID;
+                LocationID2 = loc2ID;
+            }
+            public long LocationID1;
+            public long LocationID2;
+            public bool HasCheckedBothLocations() => APEvents.IsConnected &&
+                APEvents.Session.Locations.AllLocationsChecked.Contains(LocationID1) &&
+                APEvents.Session.Locations.AllLocationsChecked.Contains(LocationID2);
+            public override bool VisibleInSongList() => HasReceivedSong() && !HasCheckedBothLocations();
+            public override bool CanCompleteLocation() => HasReceivedSong() && !HasCheckedBothLocations();
+        }
+
         public static List<DeathLinkMessage> DeathLinkMessages = new()
         {
             new("got boo'd offstage."),
@@ -32,7 +103,6 @@ namespace YARG.Assets.Script.YargAP
             public bool Valid(Instrument instrument) => InstrumentTags.Count == 0 || InstrumentTags.Contains(instrument);
         }
 
-        public static bool NeedsRegen = true;
         public enum APFiller
         {
             YargGem = 1,
@@ -50,32 +120,6 @@ namespace YARG.Assets.Script.YargAP
             song = 1,
             gems = 2,
             both = 3
-        }
-
-        public static Dictionary<string, int[]> SongNames = new Dictionary<string, int[]>();
-
-        private static Dictionary<string, long[]> _SongNameToAPLocations;
-        public static Dictionary<string, long[]> SongHashToAPLocations()
-        {
-            if (_SongNameToAPLocations is not null && !NeedsRegen)
-                return _SongNameToAPLocations;
-            _SongNameToAPLocations = new();
-            foreach (var i in SongNames)
-                _SongNameToAPLocations[i.Key] = new long[] { i.Value[0], i.Value[1] };
-            NeedsRegen = false;
-            return _SongNameToAPLocations;
-        }
-
-        private static Dictionary<long, string> _APItemIDToSongName;
-        public static Dictionary<long, string> APItemIDToHash()
-        {
-            if (_APItemIDToSongName is not null && !NeedsRegen)
-                return _APItemIDToSongName;
-            _APItemIDToSongName = new();
-            foreach (var i in SongNames)
-                _APItemIDToSongName[i.Value[2]] = i.Key;
-            NeedsRegen = false;
-            return _APItemIDToSongName;
         }
     }
 }

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -24,25 +24,18 @@ namespace YARG.Assets.Script.YargAP
     {
         public static APData.APSongLocation[]   APSongLocations     = Array.Empty<APData.APSongLocation>();
         public static APData.APGoalSong         APGoalSong          = null;
-        public static APData.GoalDisplaySetting GoalDisplaySetting  = APData.GoalDisplaySetting.both;
+        public static APData.GoalDisplaySetting GoalDisplaySetting  = APData.GoalDisplaySetting.BOTH;
         public static GameManager               CurrentSong         = null;
         public static bool                      PrintChatMessages   = true;
         public static bool                      PrintUnrelatedItems = false;
         public static ArchipelagoSession        Session;
         public static DeathLinkService          DeathLinkService;
-        public static APData.DeathLinkType      DeathLinkType       = APData.DeathLinkType.RockMeter;
-        public static int                       DeathLinkOverride   = 0;
+        public static APData.DeathLinkType      DeathLinkType       = APData.DeathLinkType.DISABLED;
+        public static APData.DeathLinkType      DeathLinkYAML       = APData.DeathLinkType.DISABLED;
+        public static APData.EnergyLinkType     EnergyLinkType      = APData.EnergyLinkType.ENABLED;
+        public static APData.EnergyLinkType     EnergyLinkYAML      = APData.EnergyLinkType.ENABLED;
         private static readonly System.Random   SeedRng             = new();
         public static bool                      IsConnected => Session?.Socket != null && APEvents.Session.Socket.Connected;
-
-        public static APData.DeathLinkType GetDeathLinkSetting()
-        {
-            if (DeathLinkOverride == 2)
-                return APData.DeathLinkType.Fail;
-            if (DeathLinkOverride == 3)
-                return APData.DeathLinkType.RockMeter;
-            return DeathLinkType;
-        }
 
         public static void Items_ItemReceived(Archipelago.MultiClient.Net.Helpers.ReceivedItemsHelper helper)
         {
@@ -100,16 +93,15 @@ namespace YARG.Assets.Script.YargAP
 
         public static void ProcessDeathLink(DeathLink deathLink)
         {
-            if (CurrentSong == null || DeathLinkOverride == 1)
+            if (CurrentSong == null || DeathLinkType <= APData.DeathLinkType.DISABLED)
                 return;
-            var type = GetDeathLinkSetting();
             ToastManager.ToastError($"{deathLink.Source} {deathLink.Cause}");
-            switch (type)
+            switch (DeathLinkType)
             {
-                case APData.DeathLinkType.Fail:
+                case APData.DeathLinkType.INSTANT:
                     _ = CurrentSong.ForceSongFail();
                     break;
-                case APData.DeathLinkType.RockMeter:
+                case APData.DeathLinkType.ONE_HIT:
                     //Set each players rock meter low enough that one missed note causes a fail.
                     foreach (var player in CurrentSong.Players)
                     {
@@ -144,6 +136,14 @@ namespace YARG.Assets.Script.YargAP
             dynamic token = Newtonsoft.Json.Linq.JToken.FromObject(0);
             dataStorage.Initialize(token);
             APEvents.Session.DataStorage[DeathLinkKey] += amount;
+        }
+
+        public static void UpdateDeathLinkTag()
+        {
+            if (DeathLinkType > APData.DeathLinkType.DISABLED)
+                DeathLinkService.EnableDeathLink();
+            else
+                DeathLinkService.DisableDeathLink();
         }
 
     }

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -136,5 +136,15 @@ namespace YARG.Assets.Script.YargAP
             return Selected;
         }
 
+        public static void SendEnergy(int amount)
+        {
+            if (!IsConnected) return;
+            string DeathLinkKey = $"EnergyLink{APEvents.Session.Players.ActivePlayer.Team}";
+            dynamic dataStorage = APEvents.Session.DataStorage[DeathLinkKey];
+            dynamic token = Newtonsoft.Json.Linq.JToken.FromObject(0);
+            dataStorage.Initialize(token);
+            APEvents.Session.DataStorage[DeathLinkKey] += amount;
+        }
+
     }
 }

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -8,80 +8,49 @@ using System.Reflection;
 using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using UnityEngine;
 using YARG.Core.Extensions;
+using YARG.Core.Song;
 using YARG.Gameplay;
 using YARG.Gameplay.Player;
 using YARG.Menu.Persistent;
+using YARG.Song;
 using static UnityEngine.Rendering.DebugUI;
 
 namespace YARG.Assets.Script.YargAP
 {
     internal class APEvents
     {
-        public static string GoalSong;
-        public static int GoalItemCount = 0;
-        public static int GoalItemNeeded = 0;
-        public static APData.GoalDisplaySetting goalDisplaySetting = APData.GoalDisplaySetting.both;
-        public static GameManager CurrentSong = null;
-        public static bool PrintChatMessages = true;
-        public static bool PrintUnrelatedItems = false;
-        public static ArchipelagoSession session;
-        public static DeathLinkService deathLinkService;
-        public static APData.DeathLinkType deathLinkType = APData.DeathLinkType.RockMeter;
-        public static int deathLinkOverride = 0;
-        public static System.Random random = new System.Random();
-        public static bool _isConnected => APEvents.session?.Socket != null && APEvents.session.Socket.Connected;
-
-        public static HashSet<string> RecievedSongs = new HashSet<string>();
+        public static APData.APSongLocation[]   APSongLocations     = Array.Empty<APData.APSongLocation>();
+        public static APData.APGoalSong         APGoalSong          = null;
+        public static APData.GoalDisplaySetting GoalDisplaySetting  = APData.GoalDisplaySetting.both;
+        public static GameManager               CurrentSong         = null;
+        public static bool                      PrintChatMessages   = true;
+        public static bool                      PrintUnrelatedItems = false;
+        public static ArchipelagoSession        Session;
+        public static DeathLinkService          DeathLinkService;
+        public static APData.DeathLinkType      DeathLinkType       = APData.DeathLinkType.RockMeter;
+        public static int                       DeathLinkOverride   = 0;
+        private static readonly System.Random   SeedRng             = new();
+        public static bool                      IsConnected => Session?.Socket != null && APEvents.Session.Socket.Connected;
 
         public static APData.DeathLinkType GetDeathLinkSetting()
         {
-            if (deathLinkOverride == 2)
+            if (DeathLinkOverride == 2)
                 return APData.DeathLinkType.Fail;
-            if (deathLinkOverride == 3)
+            if (DeathLinkOverride == 3)
                 return APData.DeathLinkType.RockMeter;
-            return deathLinkType;
-        }
-
-        public static void UpdateRecievedSongs()
-        {
-            if (!_isConnected)
-                return;
-
-            GoalItemCount = 0;
-            foreach (var item in session.Items.AllItemsReceived)
-            {
-                if (APData.APItemIDToHash().TryGetValue(item.ItemId, out var data))
-                    RecievedSongs.Add(data);
-                if (item.ItemId == (long)APData.APFiller.YargGem)
-                    GoalItemCount++;
-            }
-            Debug.Log($"Goal Progress {GoalItemCount}/{GoalItemNeeded}");
-            Debug.Log($"Unlocked Goal Song {RecievedSongs.Contains(APEvents.GoalSong)}");
-        }
-
-        public static HashSet<string> GetUnplayedAvailableLocations()
-        {
-            HashSet<string> AvailableSongLocations = new();
-            if (!_isConnected)
-                return AvailableSongLocations;
-            foreach (var i in RecievedSongs)
-            {
-                if (APData.SongHashToAPLocations().TryGetValue(i, out var locations) &&  locations.Any(x => !session.Locations.AllLocationsChecked.Contains(x)))
-                    AvailableSongLocations.Add(i);
-            }
-            return AvailableSongLocations;
+            return DeathLinkType;
         }
 
         public static void Items_ItemReceived(Archipelago.MultiClient.Net.Helpers.ReceivedItemsHelper helper)
         {
-            UpdateRecievedSongs();
+            APGoalSong?.UpdateGoalItems();
             while (helper.Any())
             {
                 var item = helper.DequeueItem();
 
-                //Item ID 1 is Yarg Gem, for now I just made it grant star power
                 if (item.ItemId == (long) APData.APFiller.StarPower && CurrentSong != null)
                     foreach (var i in CurrentSong.Players)
                         ApplyStarPowerItem(i, CurrentSong);
@@ -100,15 +69,12 @@ namespace YARG.Assets.Script.YargAP
         private static MethodInfo _gainStarPower;
         public static void ApplyStarPowerItem(BasePlayer player, GameManager handler)
         {
-            if (handler == null)
-                return;
-
+            if (handler == null) return;
             Debug.Log("Processing Star Power Item");
-
             var engine = player.BaseEngine;
             if (engine == null) return;
 
-            //Since we can;t edit yarg core, we have to use reflection to call GainStarPower since it is private
+            //Since we can't edit yarg core, we have to use reflection to call GainStarPower since it is private
             _gainStarPower ??= engine.GetType().GetMethod("GainStarPower", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
 
             if (_gainStarPower == null)
@@ -121,22 +87,20 @@ namespace YARG.Assets.Script.YargAP
 
         internal static void TryCheckSongLocation(GameManager gameManager)
         {
-            if (!_isConnected || !RecievedSongs.Contains(gameManager.Song.Name))
-                return;
+            if (!IsConnected) return;
+            var matchingAPLocation = APSongLocations.FirstOrDefault(x => x.MatchesSongEntry(gameManager.Song));
 
-            if (APData.SongHashToAPLocations().TryGetValue(gameManager.Song.Name, out var Locations))
-                session.Locations.CompleteLocationChecksAsync(Locations);
+            if (matchingAPLocation != null && matchingAPLocation.CanCompleteLocation() && matchingAPLocation.MetPlayRequirements(gameManager))
+                Session.Locations.CompleteLocationChecksAsync(matchingAPLocation.LocationID1, matchingAPLocation.LocationID2);
 
-            if (GoalSong != null && GoalSong == gameManager.Song.Name && CanCompleteGoalSong())
-                session.SetGoalAchieved();
+            if (APGoalSong is not null && APGoalSong.MatchesSongEntry(gameManager.Song) && APGoalSong.CanCompleteLocation() && APGoalSong.MetPlayRequirements(gameManager))
+                Session.SetGoalAchieved();
 
         }
 
-        public static bool CanCompleteGoalSong() => _isConnected && RecievedSongs.Contains(GoalSong) && GoalItemCount >= GoalItemNeeded;
-
         public static void ProcessDeathLink(DeathLink deathLink)
         {
-            if (CurrentSong == null || deathLinkOverride == 1)
+            if (CurrentSong == null || DeathLinkOverride == 1)
                 return;
             var type = GetDeathLinkSetting();
             ToastManager.ToastError($"{deathLink.Source} {deathLink.Cause}");
@@ -168,8 +132,9 @@ namespace YARG.Assets.Script.YargAP
                         AllMessages.Add(message.Message);
                 }
             }
-            var Selected = AllMessages.PickRandom(random);
+            var Selected = AllMessages.PickRandom(SeedRng);
             return Selected;
         }
+
     }
 }

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -37,6 +37,8 @@ namespace YARG.Assets.Script.YargAP
         private static readonly System.Random   SeedRng             = new();
         public static bool                      IsConnected => Session?.Socket != null && APEvents.Session.Socket.Connected;
 
+        public static string DeathLinkKey => IsConnected ? $"EnergyLink{Session.Players.ActivePlayer.Team}" : "";
+
         public static void Items_ItemReceived(Archipelago.MultiClient.Net.Helpers.ReceivedItemsHelper helper)
         {
             APGoalSong?.UpdateGoalItems();
@@ -128,14 +130,27 @@ namespace YARG.Assets.Script.YargAP
             return Selected;
         }
 
+        const long minScale = 20000;
+        const long maxScale = 1000000;
         public static void SendEnergy(int amount)
         {
             if (!IsConnected) return;
-            string DeathLinkKey = $"EnergyLink{APEvents.Session.Players.ActivePlayer.Team}";
-            dynamic dataStorage = APEvents.Session.DataStorage[DeathLinkKey];
+
+            int AmountOfLocationsTotal = Session.Locations.AllLocations.Count;
+            int AmountOfLocationsChecked = Session.Locations.AllLocationsChecked.Count;
+            double completionPercentage = AmountOfLocationsChecked / AmountOfLocationsTotal;
+            double scale = minScale + (completionPercentage * (maxScale - minScale));
+            long Energy = (long)(amount * scale);
+
+            InitializeEnergyLink();
+            Session.DataStorage[DeathLinkKey] += Energy;
+        }
+
+        public static void InitializeEnergyLink()
+        {
+            dynamic dataStorage = Session.DataStorage[DeathLinkKey];
             dynamic token = Newtonsoft.Json.Linq.JToken.FromObject(0);
             dataStorage.Initialize(token);
-            APEvents.Session.DataStorage[DeathLinkKey] += amount;
         }
 
         public static void UpdateDeathLinkTag()

--- a/Assets/Script/YargAP/APEvents.cs
+++ b/Assets/Script/YargAP/APEvents.cs
@@ -37,6 +37,9 @@ namespace YARG.Assets.Script.YargAP
         private static readonly System.Random   SeedRng             = new();
         public static bool                      IsConnected => Session?.Socket != null && APEvents.Session.Socket.Connected;
 
+        const long minScale = 20000;
+        const long maxScale = 1000000;
+
         public static string DeathLinkKey => IsConnected ? $"EnergyLink{Session.Players.ActivePlayer.Team}" : "";
 
         public static void Items_ItemReceived(Archipelago.MultiClient.Net.Helpers.ReceivedItemsHelper helper)
@@ -130,20 +133,41 @@ namespace YARG.Assets.Script.YargAP
             return Selected;
         }
 
-        const long minScale = 20000;
-        const long maxScale = 1000000;
         public static void SendEnergy(int amount)
         {
             if (!IsConnected) return;
 
-            int AmountOfLocationsTotal = Session.Locations.AllLocations.Count;
-            int AmountOfLocationsChecked = Session.Locations.AllLocationsChecked.Count;
+            try
+            {
+                InitializeEnergyLink();
+                long Energy = ApplyScale(amount, Session.Locations.AllLocations.Count, Session.Locations.AllLocationsChecked.Count);
+                Session.DataStorage[DeathLinkKey] += Energy;
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                ToastManager.ToastError(e.ToString());
+            }
+        }
+
+        public static long ApplyScale(long Score, double AmountOfLocationsTotal, double AmountOfLocationsChecked)
+        {
             double completionPercentage = AmountOfLocationsChecked / AmountOfLocationsTotal;
             double scale = minScale + (completionPercentage * (maxScale - minScale));
-            long Energy = (long)(amount * scale);
+            return (long) (Score * scale);
+        }
 
-            InitializeEnergyLink();
-            Session.DataStorage[DeathLinkKey] += Energy;
+        public static void TestScaleFactor()
+        {
+            var Score = 200_000;
+            var TotalLocations = 20;
+
+            Dictionary<int, long> Tests = new Dictionary<int, long>();
+            for (var checkedLocations = 0; checkedLocations <= TotalLocations; checkedLocations++)
+            {
+                Tests[checkedLocations] = ApplyScale(Score, TotalLocations, checkedLocations);
+            }
+            Debug.Log(Newtonsoft.Json.JsonConvert.SerializeObject(Tests,  Newtonsoft.Json.Formatting.Indented));
         }
 
         public static void InitializeEnergyLink()

--- a/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
+++ b/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
@@ -54,24 +54,24 @@ namespace YARG.Assets.Script.YargAP
 
             GUILayout.BeginVertical(GUILayout.Width(180));
             GUILayout.Label("Address");
-            using (new GUIEnabledScope(!APEvents._isConnected))
+            using (new GUIEnabledScope(!APEvents.IsConnected))
                 address = GUILayout.TextField(address);
 
             GUILayout.Label("Slot Name");
-            using (new GUIEnabledScope(!APEvents._isConnected))
+            using (new GUIEnabledScope(!APEvents.IsConnected))
                 slotName = GUILayout.TextField(slotName);
 
             GUILayout.Label("Password");
-            using (new GUIEnabledScope(!APEvents._isConnected))
+            using (new GUIEnabledScope(!APEvents.IsConnected))
                 password = GUILayout.PasswordField(password, '*');
 
             GUILayout.Space(10);
-            string buttonText = APEvents._isConnected ? "Disconnect" : "Connect";
+            string buttonText = APEvents.IsConnected ? "Disconnect" : "Connect";
             if (GUILayout.Button(buttonText, GUILayout.Height(28)))
             {
                 GUI.FocusControl(null);
                 GUIUtility.keyboardControl = 0;
-                if (APEvents._isConnected)
+                if (APEvents.IsConnected)
                     DoDisconnect();
                 else
                     DoConnect();
@@ -84,19 +84,19 @@ namespace YARG.Assets.Script.YargAP
 
             GUILayout.Label("Deathlink Status");
 
-            string statusText = APEvents._isConnected ? (APEvents.deathLinkService != null ? "-Enabled by YAML" : "-Disabled by YAML") : "-Not Connected";
+            string statusText = APEvents.IsConnected ? (APEvents.DeathLinkService != null ? "-Enabled by YAML" : "-Disabled by YAML") : "-Not Connected";
             GUILayout.Label(statusText);
 
             GUILayout.Label("Deathlink Setting Override");
 
-            using (new GUIEnabledScope(APEvents._isConnected && APEvents.deathLinkService != null))
+            using (new GUIEnabledScope(APEvents.IsConnected && APEvents.DeathLinkService != null))
             {
-                if (GUILayout.Button(deathLinkOptions[APEvents.deathLinkOverride], GUILayout.Height(20)))
+                if (GUILayout.Button(deathLinkOptions[APEvents.DeathLinkOverride], GUILayout.Height(20)))
                 {
-                    var NewVal = APEvents.deathLinkOverride + 1;
+                    var NewVal = APEvents.DeathLinkOverride + 1;
                     if (NewVal >= deathLinkOptions.Length)
                         NewVal = 0;
-                    APEvents.deathLinkOverride = NewVal;
+                    APEvents.DeathLinkOverride = NewVal;
                 }
             }
 

--- a/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
+++ b/Assets/Script/YargAP/ArchipelagoConnectionDialog.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using YARG.Helpers;
 using YARG.Menu.Persistent;
 using YARG.Song;
 
@@ -25,10 +26,12 @@ namespace YARG.Assets.Script.YargAP
         [SerializeField] private string slotName = "";
         [SerializeField] private string password = "";
 
-        private string[] deathLinkOptions = { "use yaml", "disabled", "instant", "one hit" };
-        private bool showDeathlinkDropdown = false;
+        private int DeathLinkOverride = APData.DeathLinkValues.Length;
+        private int EnergyLinkOverride = APData.EnergyLinkValues.Length;
 
-        private Rect _windowRect = new Rect(20, 20, 400, 260);
+        private bool     showDeathlinkDropdown = false;
+
+        private Rect _windowRect = new Rect(20, 20, 430, 260);
 
         private void Awake()
         {
@@ -40,6 +43,14 @@ namespace YARG.Assets.Script.YargAP
 
             Instance = this;
             DontDestroyOnLoad(gameObject);
+
+            var Cache = APConnectionHelper.LoadConnectionCache();
+            if (Cache is not null)
+            {
+                address = $"{Cache.IP}:{Cache.Port}";
+                slotName = Cache.SlotName;
+                password = Cache.Password;
+            }
         }
 
         private void OnGUI()
@@ -76,27 +87,50 @@ namespace YARG.Assets.Script.YargAP
                 else
                     DoConnect();
             }
+            GUILayout.Space(6);
+            if (GUILayout.Button("Close", GUILayout.Height(28)))
+                Show = false;
             GUILayout.EndVertical();
 
             GUILayout.Space(20);
 
-            GUILayout.BeginVertical(GUILayout.Width(180));
+            GUILayout.BeginVertical(GUILayout.Width(190));
 
-            GUILayout.Label("Deathlink Status");
+            GUILayout.Label($"Deathlink YAML: {(APEvents.IsConnected ? APEvents.DeathLinkYAML.GetDescription() : "N/A")}");
 
-            string statusText = APEvents.IsConnected ? (APEvents.DeathLinkService != null ? "-Enabled by YAML" : "-Disabled by YAML") : "-Not Connected";
-            GUILayout.Label(statusText);
-
-            GUILayout.Label("Deathlink Setting Override");
+            GUILayout.Label("Deathlink Override");
 
             using (new GUIEnabledScope(APEvents.IsConnected && APEvents.DeathLinkService != null))
             {
-                if (GUILayout.Button(deathLinkOptions[APEvents.DeathLinkOverride], GUILayout.Height(20)))
+                var Display = DeathLinkOverride == APData.DeathLinkValues.Length ? "Use Yaml" : APEvents.DeathLinkType.GetDescription();
+                if (GUILayout.Button(Display, GUILayout.Height(20)))
                 {
-                    var NewVal = APEvents.DeathLinkOverride + 1;
-                    if (NewVal >= deathLinkOptions.Length)
-                        NewVal = 0;
-                    APEvents.DeathLinkOverride = NewVal;
+                    DeathLinkOverride++;
+                    if (DeathLinkOverride > APData.DeathLinkValues.Length) DeathLinkOverride = 0;
+                    if (DeathLinkOverride == APData.DeathLinkValues.Length)
+                        APEvents.DeathLinkType = APEvents.DeathLinkYAML;
+                    else
+                        APEvents.DeathLinkType = APData.DeathLinkValues[DeathLinkOverride];
+                    APEvents.UpdateDeathLinkTag();
+                    Debug.Log($"{DeathLinkOverride} | {APEvents.DeathLinkType} | {APEvents.DeathLinkYAML}");
+                }
+            }
+
+            GUILayout.Label($"Energylink YAML: {(APEvents.IsConnected ? APEvents.EnergyLinkYAML.GetDescription() : "N/A")}");
+
+            GUILayout.Label("Energylink Override");
+            using (new GUIEnabledScope(APEvents.IsConnected))
+            {
+                var Display = EnergyLinkOverride == APData.EnergyLinkValues.Length ? "Use Yaml" : APEvents.EnergyLinkType.GetDescription();
+                if (GUILayout.Button(Display, GUILayout.Height(20)))
+                {
+                    EnergyLinkOverride++;
+                    if (EnergyLinkOverride > APData.EnergyLinkValues.Length) EnergyLinkOverride = 0;
+                    if (EnergyLinkOverride == APData.EnergyLinkValues.Length)
+                        APEvents.EnergyLinkType = APEvents.EnergyLinkYAML;
+                    else
+                        APEvents.EnergyLinkType = APData.EnergyLinkValues[EnergyLinkOverride];
+                    Debug.Log($"{EnergyLinkOverride} | {APEvents.EnergyLinkType} | {APEvents.EnergyLinkYAML}");
                 }
             }
 
@@ -111,10 +145,6 @@ namespace YARG.Assets.Script.YargAP
             GUILayout.EndVertical();
 
             GUILayout.EndHorizontal();
-
-            GUILayout.Space(6);
-            if (GUILayout.Button("Close"))
-                Show = false;
 
             GUI.DragWindow(new Rect(0, 0, 10000, 20));
         }


### PR DESCRIPTION
-Major Refactor of the AP Code
-Songs now compare against both song name and source when parsing between yarg and AP
-Make the Archipelago menu option open the original popup menu until the built in menu is complete
-Disable Saving Replays
-Add the ability to send energy equal to your song score to the energy link bank.
-Add a connection cache. The last successful connection will be prefilled in the connection dialog.
-Deathlink can now be enabled by the override setting even if it was disabled in the yaml
-Improve deathlink and energy link setting management
-Rework the connection menu to better fit settings